### PR TITLE
No calls pending batch 'calls' if the 'executor' throws

### DIFF
--- a/batch/accumulate_test.ts
+++ b/batch/accumulate_test.ts
@@ -580,6 +580,7 @@ test({
       ]);
     });
     await t.step("if the executor throws", async (t) => {
+      using denops_batch = spy(denops, "batch");
       await t.step("rejects an error", async () => {
         await assertRejects(
           async () => {
@@ -591,6 +592,9 @@ test({
           Error,
           "test error",
         );
+      });
+      await t.step("does not calls pending batch 'calls'", () => {
+        assertSpyCalls(denops_batch, 0);
       });
     });
     await t.step("if the executor rejects", async (t) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced asynchronous call handling with a clearer stopping mechanism in the AccumulateHelper.
	- Improved performance for processing multiple calls through concurrent execution.

- **Bug Fixes**
	- Streamlined error handling in tests for the accumulate function, ensuring consistent behavior across error scenarios.

- **Refactor**
	- Renamed method from `#getCalls` to `#dequeueCalls` for improved clarity.
	- Consolidated and restructured test cases for better readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->