### PR TITLE
fix: implement `Denops.interrupted` property to AccumulateHelper

### DIFF
--- a/batch/accumulate.ts
+++ b/batch/accumulate.ts
@@ -38,6 +38,10 @@ class AccumulateHelper implements Denops {
     return this.#denops.meta;
   }
 
+  get interrupted(): AbortSignal | undefined {
+    return this.#denops.interrupted;
+  }
+
   get context(): Record<string | number | symbol, unknown> {
     return this.#denops.context;
   }

--- a/batch/accumulate_test.ts
+++ b/batch/accumulate_test.ts
@@ -2,6 +2,7 @@ import { delay } from "@std/async";
 import { assertEquals, assertRejects, assertStrictEquals } from "@std/assert";
 import { assertType, type IsExact } from "@std/testing/types";
 import { assertSpyCalls, resolvesNext, spy, stub } from "@std/testing/mock";
+import { DisposableStack } from "@nick/dispose";
 import { BatchError, type Denops } from "@denops/core";
 import { batch, collect } from "@denops/std/batch";
 import { DenopsStub, test } from "@denops/test";
@@ -725,12 +726,21 @@ test({
         };
 
         await t.step("setter sets to 'denops.dispatcher'", async () => {
+          using stack = new DisposableStack();
+          stack.adopt(denops.dispatcher, (saved) => {
+            denops.dispatcher = saved;
+          });
           await accumulate(denops, (helper) => {
             helper.dispatcher = MY_DISPATCHER;
           });
           assertStrictEquals(denops.dispatcher, MY_DISPATCHER);
         });
         await t.step("getter returns 'denops.dispatcher'", async () => {
+          using stack = new DisposableStack();
+          stack.adopt(denops.dispatcher, (saved) => {
+            denops.dispatcher = saved;
+          });
+          denops.dispatcher = MY_DISPATCHER;
           let actual: unknown;
           await accumulate(denops, (helper) => {
             actual = helper.dispatcher;

--- a/batch/accumulate_test.ts
+++ b/batch/accumulate_test.ts
@@ -711,6 +711,15 @@ test({
           assertStrictEquals(actual, denops.meta);
         });
       });
+      await t.step(".interrupted", async (t) => {
+        await t.step("getter returns 'denops.interrupted'", async () => {
+          let actual: unknown;
+          await accumulate(denops, (helper) => {
+            actual = helper.interrupted;
+          });
+          assertStrictEquals(actual, denops.interrupted);
+        });
+      });
       await t.step(".context", async (t) => {
         await t.step("getter returns 'denops.context'", async () => {
           let actual: unknown;

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -35,6 +35,7 @@
     "@denops/core": "jsr:@denops/core@^7.0.0",
     "@denops/std": "jsr:@denops/std@^7.0.0",
     "@denops/test": "jsr:@denops/test@^3.0.1",
+    "@nick/dispose": "jsr:@nick/dispose@^1.1.0",
     "@std/assert": "jsr:@std/assert@^1.0.0",
     "@std/async": "jsr:@std/async@^1.0.1",
     "@std/testing": "jsr:@std/testing@1.0.0-rc.5",

--- a/deno.lock
+++ b/deno.lock
@@ -17,6 +17,7 @@
       "jsr:@lambdalisue/messagepack@^1.0.1": "jsr:@lambdalisue/messagepack@1.0.1",
       "jsr:@lambdalisue/reservator@^1.0.1": "jsr:@lambdalisue/reservator@1.0.1",
       "jsr:@lambdalisue/streamtools@^1.0.0": "jsr:@lambdalisue/streamtools@1.0.0",
+      "jsr:@nick/dispose@^1.1.0": "jsr:@nick/dispose@1.1.0",
       "jsr:@std/assert@^1.0.0": "jsr:@std/assert@1.0.1",
       "jsr:@std/assert@^1.0.1": "jsr:@std/assert@1.0.1",
       "jsr:@std/async@1.0.0": "jsr:@std/async@1.0.0",
@@ -99,6 +100,9 @@
         "dependencies": [
           "jsr:@std/bytes@^0.221.0"
         ]
+      },
+      "@nick/dispose@1.1.0": {
+        "integrity": "73a15b90cb48e1435801258ba3ac7a19382823349dedcacbb8e5b5b673ce9d17"
       },
       "@std/assert@1.0.1": {
         "integrity": "13590ef8e5854f59e4ad252fd987e83239a1bf1f16cb9c69c1d123ebb807a75b",
@@ -213,6 +217,7 @@
       "jsr:@denops/core@^7.0.0",
       "jsr:@denops/std@^7.0.0",
       "jsr:@denops/test@^3.0.1",
+      "jsr:@nick/dispose@^1.1.0",
       "jsr:@std/assert@^1.0.0",
       "jsr:@std/async@^1.0.1",
       "jsr:@std/testing@1.0.0-rc.5"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `interrupted` property to the `AccumulateHelper` class, enhancing asynchronous operation handling.
	- Added a new dependency for improved resource management.

- **Bug Fixes**
	- Enhanced test suite for the `denops` object, ensuring accurate reflection of the interrupted state and improving test reliability.

- **Tests**
	- Expanded test coverage with new cases for the `denops` object and improved state management during tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->