### PR TITLE
chore(package): separate jsr.jsonc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Publish
-        run: deno run -A jsr:@david/publish-on-tag@0.2.0
+        run: deno run -A jsr:@david/publish-on-tag@0.2.0 --config jsr.jsonc

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,21 +1,7 @@
 {
-  "name": "@milly/denops-batch-accumulate",
-  "exports": {
-    ".": "./batch/accumulate.ts"
-  },
   "exclude": [
     ".coverage/"
   ],
-  "publish": {
-    "include": [
-      "LICENSE",
-      "README.md",
-      "**/*.ts"
-    ],
-    "exclude": [
-      "**/*_test.ts"
-    ]
-  },
   "fmt": {
     "exclude": [
       "README.md"
@@ -24,7 +10,7 @@
   "tasks": {
     "check": "deno lint && deno fmt --check && deno check --no-lock **/*.ts",
     "check:doc": "deno test --doc --no-run --no-lock",
-    "check:publish": "deno publish --dry-run --set-version=0.0.0",
+    "check:publish": "deno publish --dry-run --config jsr.jsonc --set-version=0.0.0",
     "bench": "deno bench -A --no-lock",
     "test": "LANG=C deno test -A --doc --parallel --shuffle --no-lock",
     "test:coverage": "LANG=C deno task test --coverage=.coverage",

--- a/jsr.jsonc
+++ b/jsr.jsonc
@@ -1,0 +1,20 @@
+{
+  "name": "@milly/denops-batch-accumulate",
+  "exports": {
+    ".": "./batch/accumulate.ts"
+  },
+  "imports": {
+    "@denops/core": "jsr:@denops/core@^7.0.0"
+  },
+  "publish": {
+    "include": [
+      "LICENSE",
+      "README.md",
+      "**/*.ts"
+    ],
+    "exclude": [
+      "**/*_bench.ts",
+      "**/*_test.ts"
+    ]
+  }
+}


### PR DESCRIPTION
Deno 1.x does not support omitting the `version` field in the *deno.jsonc* file, so it has been separated into *jsr.jsonc*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new configuration file to manage package publishing settings and dependencies.
  * Updated workflow and configuration to use the new configuration file during the publish process.
  * Simplified existing configuration by removing unused sections and updating task commands for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->