### PR TITLE
fix: correct stack traces in AccumulateHelper

### DIFF
--- a/batch/accumulate.ts
+++ b/batch/accumulate.ts
@@ -96,8 +96,12 @@ class AccumulateHelper implements Denops {
     return await this.call("denops#api#eval", expr, ctx);
   }
 
-  dispatch(name: string, fn: string, ...args: unknown[]): Promise<unknown> {
-    return this.#denops.dispatch(name, fn, ...args);
+  async dispatch(
+    name: string,
+    fn: string,
+    ...args: unknown[]
+  ): Promise<unknown> {
+    return await this.#denops.dispatch(name, fn, ...args);
   }
 
   #ensureAvailable(): void {


### PR DESCRIPTION
The stack trace for errors in asynchronously executed Vim calls now correctly reflects that they originated from methods within the AccumulateHelper.

Added tests for each method.