### PR TITLE
feat: change error type to TypeError for closed AccumulateHelper usage

### DIFF
--- a/batch/accumulate.ts
+++ b/batch/accumulate.ts
@@ -106,7 +106,7 @@ class AccumulateHelper implements Denops {
 
   #ensureAvailable(): void {
     if (this.#closed) {
-      throw new Error(
+      throw new TypeError(
         "AccumulateHelper instance is not available outside of 'accumulate' block",
       );
     }

--- a/batch/accumulate_test.ts
+++ b/batch/accumulate_test.ts
@@ -417,7 +417,7 @@ test({
         ]);
       });
       await t.step("rejects subsequent batch 'calls'", async () => {
-        await assertRejects(() => p, Error, "not available outside");
+        await assertRejects(() => p, TypeError, "not available outside");
       });
     });
     await t.step("when the executor throws", async (t) => {
@@ -444,7 +444,7 @@ test({
         ]);
       });
       await t.step("rejects subsequent batch 'calls'", async () => {
-        await assertRejects(() => p, Error, "not available outside");
+        await assertRejects(() => p, TypeError, "not available outside");
       });
     });
     await t.step("when the executor rejects", async (t) => {
@@ -471,7 +471,7 @@ test({
         ]);
       });
       await t.step("rejects subsequent batch 'calls'", async () => {
-        await assertRejects(() => p, Error, "not available outside");
+        await assertRejects(() => p, TypeError, "not available outside");
       });
     });
     await t.step("AccumulateHelper", async (t) => {
@@ -824,7 +824,7 @@ test({
           await t.step("rejects an error", async () => {
             await assertRejects(
               () => helper_outside.call("range", 0),
-              Error,
+              TypeError,
               "not available outside",
             );
           });
@@ -842,7 +842,7 @@ test({
           await t.step("rejects an error", async () => {
             await assertRejects(
               () => helper_outside.cmd("echo 'hello'"),
-              Error,
+              TypeError,
               "not available outside",
             );
           });
@@ -860,7 +860,7 @@ test({
           await t.step("rejects an error", async () => {
             await assertRejects(
               () => helper_outside.eval("123"),
-              Error,
+              TypeError,
               "not available outside",
             );
           });
@@ -878,7 +878,7 @@ test({
           await t.step("rejects an error", async () => {
             await assertRejects(
               () => helper_outside.batch(["range", 0]),
-              Error,
+              TypeError,
               "not available outside",
             );
           });


### PR DESCRIPTION
Using TypeError is more semantically correct when attempting to use a closed AccumulateHelper instance, as it represents improper use of an object type that is no longer in a valid state for operations.