### PR TITLE
feat: Use Call type from @denops/core v8.0.1 

### DIFF
--- a/batch/accumulate.ts
+++ b/batch/accumulate.ts
@@ -1,11 +1,9 @@
 import { nextTick } from "node:process";
-import type { Context, Denops, Dispatcher, Meta } from "@denops/core";
+import type { Call, Context, Denops, Dispatcher, Meta } from "@denops/core";
 import { BatchError } from "@denops/core";
 import { AccumulateCancelledError } from "./error.ts";
 
 const errorProp = Symbol("AccumulateErrorResult");
-
-type Call = [fn: string, ...args: unknown[]];
 
 type ErrorResult = {
   [errorProp]:

--- a/batch/error.ts
+++ b/batch/error.ts
@@ -1,7 +1,7 @@
-/**
- * Represents information about a Vim/Neovim function call.
- */
-export type Call = readonly [fn: string, ...args: unknown[]];
+import type { Call } from "@denops/core/type";
+
+// Re-export Call type for backward compatibility.
+export type { Call };
 
 /**
  * Options for creating an {@linkcode AccumulateCancelledError}.

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -19,7 +19,7 @@
   },
   "imports": {
     "@core/asyncutil": "jsr:@core/asyncutil@^1.2.0",
-    "@denops/core": "jsr:@denops/core@^8.0.0",
+    "@denops/core": "jsr:@denops/core@^8.0.1",
     "@denops/std": "jsr:@denops/std@^8.1.0",
     "@denops/test": "jsr:@denops/test@^4.0.0",
     "@nick/dispose": "jsr:@nick/dispose@^1.1.0",

--- a/deno.lock
+++ b/deno.lock
@@ -6,7 +6,8 @@
     "jsr:@core/unknownutil@^3.17.2": "3.18.1",
     "jsr:@core/unknownutil@^3.18.0": "3.18.1",
     "jsr:@core/unknownutil@^4.3.0": "4.3.0",
-    "jsr:@denops/core@8": "8.0.0",
+    "jsr:@denops/core@8": "8.0.1",
+    "jsr:@denops/core@^8.0.1": "8.0.1",
     "jsr:@denops/std@^8.1.0": "8.1.0",
     "jsr:@denops/test@4": "4.0.0",
     "jsr:@lambdalisue/errorutil@1": "1.1.1",
@@ -24,7 +25,7 @@
     "jsr:@std/async@^1.0.15": "1.0.15",
     "jsr:@std/bytes@0.221": "0.221.0",
     "jsr:@std/bytes@1": "1.0.6",
-    "jsr:@std/collections@^1.0.5": "1.1.2",
+    "jsr:@std/collections@^1.0.5": "1.1.3",
     "jsr:@std/data-structures@^1.0.9": "1.0.9",
     "jsr:@std/fs@^1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.10": "1.0.12",
@@ -32,8 +33,8 @@
     "jsr:@std/path@^1.0.1": "1.1.2",
     "jsr:@std/path@^1.1.1": "1.1.2",
     "jsr:@std/path@^1.1.2": "1.1.2",
-    "jsr:@std/semver@^1.0.5": "1.0.5",
-    "jsr:@std/streams@1": "1.0.12",
+    "jsr:@std/semver@^1.0.5": "1.0.6",
+    "jsr:@std/streams@1": "1.0.13",
     "jsr:@std/testing@^1.0.16": "1.0.16",
     "jsr:@std/ulid@1": "1.0.0",
     "npm:@types/node@*": "22.15.15",
@@ -49,14 +50,14 @@
     "@core/unknownutil@4.3.0": {
       "integrity": "538a3687ffa81028e91d148818047df219663d0da671d906cecd165581ae55cc"
     },
-    "@denops/core@8.0.0": {
-      "integrity": "74530f2211817f1016b7f7192f320f173bfc572b5adbd6e17451043b72a2fbdc"
+    "@denops/core@8.0.1": {
+      "integrity": "699c70b07b2347febb96972c857fb8325ad8efa99936a0a8c0bb2be82a8b8f32"
     },
     "@denops/std@8.1.0": {
       "integrity": "4a29cb86e1d83a255db3148b8b9334c69d9c179cd6aa300d08906802ecfefc83",
       "dependencies": [
         "jsr:@core/unknownutil@^4.3.0",
-        "jsr:@denops/core",
+        "jsr:@denops/core@8",
         "jsr:@lambdalisue/errorutil@^1.1.1",
         "jsr:@lambdalisue/itertools",
         "jsr:@lambdalisue/unreachable",
@@ -138,8 +139,8 @@
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
-    "@std/collections@1.1.2": {
-      "integrity": "f1685dd45c3ec27c39d0e8a642ccf810f391ec8a6cb5e7355926e6dacc64c43e"
+    "@std/collections@1.1.3": {
+      "integrity": "bf8b0818886df6a32b64c7d3b037a425111f28278d69fd0995aeb62777c986b0"
     },
     "@std/data-structures@1.0.9": {
       "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
@@ -159,11 +160,11 @@
         "jsr:@std/internal@^1.0.10"
       ]
     },
-    "@std/semver@1.0.5": {
-      "integrity": "529f79e83705714c105ad0ba55bec0f9da0f24d2f726b6cc1c15e505cc2c0624"
+    "@std/semver@1.0.6": {
+      "integrity": "b7c98ae2843547cf3f7ac37f3995889e6e4cee0a97b57b57f17f62722843303c"
     },
-    "@std/streams@1.0.12": {
-      "integrity": "ae925fa1dc459b1abf5cbaa28cc5c7b0485853af3b2a384b0dc22d86e59dfbf4"
+    "@std/streams@1.0.13": {
+      "integrity": "772d208cd0d3e5dac7c1d9e6cdb25842846d136eea4a41a62e44ed4ab0c8dd9e"
     },
     "@std/testing@1.0.16": {
       "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
@@ -255,7 +256,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@core/asyncutil@^1.2.0",
-      "jsr:@denops/core@8",
+      "jsr:@denops/core@^8.0.1",
       "jsr:@denops/std@^8.1.0",
       "jsr:@denops/test@4",
       "jsr:@nick/dispose@^1.1.0",

--- a/jsr.jsonc
+++ b/jsr.jsonc
@@ -6,7 +6,7 @@
     "./error": "./batch/error.ts"
   },
   "imports": {
-    "@denops/core": "jsr:@denops/core@^7.0.0"
+    "@denops/core": "jsr:@denops/core@^8.0.1"
   },
   "publish": {
     "include": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched internal type references to use shared types from the core library to unify type usage.
  * Re-exported the shared Call type so external consumers reference the core library's definition.
  * Updated package/import mappings to require the core library at version ^8.0.1, ensuring compatibility with the unified types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->